### PR TITLE
Assert list bug

### DIFF
--- a/cw2/cw2q4/src/cw2q4/youbotKineBase.py
+++ b/cw2/cw2q4/src/cw2q4/youbotKineBase.py
@@ -45,8 +45,8 @@ class YoubotKinematicBase(object):
 
         """
 
-        self.current_joint_position = msg.position
-        current_pose = self.forward_kinematics(msg.position)
+        self.current_joint_position = list(msg.position)
+        current_pose = self.forward_kinematics(self.current_joint_position)
         self.broadcast_pose(current_pose)
 
     def broadcast_pose(self, pose):


### PR DESCRIPTION
Fixed the assert list bug in joint callback. The joint state message is of type tuple, and in the forward kinematics function, we assert list. So typecast before sending to FK.

Related to moodle post:
Number of replies: 0
In youbotKineBase.py, joint_state_callback() function passes the joint readings to forward_kinematics() without typecasting it from a tuple to a list.

But in youbotKineStudent.py, the implementation of forward_kinematics() expects a list and even has an assert() to check if the joint readings passed to it is a list. 

When we write a node to check our code in youbotKineStudent.py, it causes assertion errors due to joint readings not being typecast in youbotKineBase.py

